### PR TITLE
Performance oriented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.swp
 *.sqlite
+cfr_cache/*

--- a/cfr_tool/__init__.py
+++ b/cfr_tool/__init__.py
@@ -1,6 +1,8 @@
 import os
 
 from flask import Flask
+import sqlite3
+from . import soup
 
 
 def create_app(test_config=None):
@@ -37,3 +39,12 @@ def create_app(test_config=None):
     app.add_url_rule('/', endpoint='packaging')
 
     return app
+
+
+def debug_harness(db_name = "instance/hazmat-parser.sqlite"):
+    from importlib import reload
+    reload(soup)
+    s2 = soup.Soup(volume=2)
+    s3 = soup.Soup(volume=3)
+    db = sqlite3.connect(db_name)
+    return s2, s3, db

--- a/cfr_tool/ibc.py
+++ b/cfr_tool/ibc.py
@@ -1,0 +1,8 @@
+import regex as re
+from .packaging_standards import PackagingStandards 
+
+class IBC(PackagingStandards):
+    START = 705
+    END = 710
+    def __init__(self, db, soup):
+        PackagingStandards.__init__(self, db, soup)

--- a/cfr_tool/ibc.py
+++ b/cfr_tool/ibc.py
@@ -1,8 +1,9 @@
 import regex as re
-from .packaging_standards import PackagingStandards 
+from . import packaging_standards as ps
 
-class IBC(PackagingStandards):
+class IBC(ps.PackagingStandards):
     START = 705
     END = 710
     def __init__(self, db, soup):
         PackagingStandards.__init__(self, db, soup)
+        self.categories = self.get_categories(self.START, self.END)

--- a/cfr_tool/nonbulk.py
+++ b/cfr_tool/nonbulk.py
@@ -2,9 +2,11 @@ import regex as re
 from . import packaging_standards as ps 
 
 class NonBulk(ps.PackagingStandards):
+    START = 504
+    END = 523
     def __init__(self, db, soup):
         ps.PackagingStandards.__init__(self, db, soup)
-        self.categories = self.get_categories()
+        self.categories = self.get_categories(self.START, self.END)
 
     def parse_kind_material(self):
         self.create_kinds_table()
@@ -36,31 +38,4 @@ class NonBulk(ps.PackagingStandards):
                     ?, ?
                 )
             '''.format(table), values)
-
-    def get_categories(self):
-        #Find the code pattern which is digits, letters, digits
-        code_pattern = re.compile("(\d+)([A-Z]+)(\d+)")
-        #Find the category name which is some text followed by "for a(n) ", preceded by ; or .
-        category_pattern = re.compile("(?<=for\sa?n?\s?)(.*)(?=[;\.])")
-        categories_data = []
-        for subpart in range(504, 524):
-            subpart_tag = self.soup.get_subpart_text(178, subpart)
-            ps = [p.text for p in subpart_tag.find_all('p')]
-            id_codes_text = [(idx, text) for idx, text in enumerate(ps) if \
-                " identification codes for " in text]
-            if len(id_codes_text) > 0:
-                start_idx = id_codes_text[0][0]
-                end_idx = [(idx, text) for idx, text in enumerate(ps) if \
-                    "Construction requirements for " in text][0][0]
-                category_code_text = ps[start_idx: end_idx]
-                for text in category_code_text:
-                    matched = code_pattern.findall(text)
-                    if matched:
-                        kind, material, category_code = code_pattern.findall(text)[0]
-                        category_desc = category_pattern.search(text).group()
-                        categories_data.append((kind + material + category_code,
-                                                int(kind),
-                                                material,
-                                                int(category_code),
-                                                category_desc))
-        return categories_data
+jkkk

--- a/cfr_tool/nonbulk.py
+++ b/cfr_tool/nonbulk.py
@@ -38,4 +38,3 @@ class NonBulk(ps.PackagingStandards):
                     ?, ?
                 )
             '''.format(table), values)
-jkkk

--- a/cfr_tool/packaging_standards.py
+++ b/cfr_tool/packaging_standards.py
@@ -1,5 +1,5 @@
 import regex as re
-import clean_text as ct
+from . import clean_text as ct
 
 
 '''
@@ -66,6 +66,33 @@ class PackagingStandards:
             )
         ''', self.categories)
 
+    def get_categories(self, start, end):
+        #Find the code pattern which is digits, letters, digits
+        code_pattern = re.compile("(\d+)([A-Z]+)(\d+)")
+        #Find the category name which is some text followed by "for a(n) ", preceded by ; or .
+        category_pattern = re.compile("(?<=for\sa?n?\s?)(.*)(?=[;\.])")
+        categories_data = []
+        for subpart in range(start, end):
+            subpart_tag = self.soup.get_subpart_text(178, subpart)
+            ps = [p.text for p in subpart_tag.find_all('p')]
+            id_codes_text = [(idx, text) for idx, text in enumerate(ps) if \
+                " identification codes for " in text]
+            if len(id_codes_text) > 0:
+                start_idx = id_codes_text[0][0]
+                end_idx = [(idx, text) for idx, text in enumerate(ps) if \
+                    "Construction requirements for " in text][0][0]
+                category_code_text = ps[start_idx: end_idx]
+                for text in category_code_text:
+                    matched = code_pattern.findall(text)
+                    if matched:
+                        kind, material, category_code = code_pattern.findall(text)[0]
+                        category_desc = category_pattern.search(text).group()
+                        categories_data.append((kind + material + category_code,
+                                                int(kind),
+                                                material,
+                                                int(category_code),
+                                                category_desc))
+        return categories_data
 
 
             

--- a/cfr_tool/soup.py
+++ b/cfr_tool/soup.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import requests
@@ -6,22 +7,27 @@ import xml.etree.ElementTree as ET
 
 class Soup:
     CACHE_DIRECTORY = "cfr_cache"
+
     def __init__(self, volume):
-        # govinfo xml url from which to parse the hazmat table
-        self.cfr = 
+        if not os.path.exists(self.CACHE_DIRECTORY):
+            os.mkdir(self.CACHE_DIRECTORY)
+        self.cfr = self.get_cfr_xml(volume)
         self.parsed_soup = bs4.BeautifulSoup(self.cfr, 'lxml')
         self.volume = volume
 
 
     def get_cfr_xml(self, volume):
+        # govinfo xml url from which to parse the hazmat table
         self.url = 'https://www.govinfo.gov/content/pkg/CFR-2019-title49-vol{}/xml/CFR-2019-title49-vol{}.xml'.format(
             str(volume), str(volume)
         )
        	self.cache_path = os.path.join(self.CACHE_DIRECTORY, self.url.split("/")[-1] )
         if os.path.exists(self.cache_path):
+            logging.info("using cached CFR volume {}".format(volume))
             with open(self.cache_path) as cache_xml:
                 xml = cache_xml.read()
         else:
+            logging.info("downloading fresh CFR volume {}".format(volume))
             xml = requests.get(self.url).text
             with open(self.cache_path, "w+") as cache_xml:
                 cache_xml.write(xml)

--- a/cfr_tool/soup.py
+++ b/cfr_tool/soup.py
@@ -21,7 +21,7 @@ class Soup:
         self.url = 'https://www.govinfo.gov/content/pkg/CFR-2019-title49-vol{}/xml/CFR-2019-title49-vol{}.xml'.format(
             str(volume), str(volume)
         )
-       	self.cache_path = os.path.join(self.CACHE_DIRECTORY, self.url.split("/")[-1] )
+        self.cache_path = os.path.join(self.CACHE_DIRECTORY, self.url.split("/")[-1] )
         if os.path.exists(self.cache_path):
             logging.info("using cached CFR volume {}".format(volume))
             with open(self.cache_path) as cache_xml:

--- a/cfr_tool/soup.py
+++ b/cfr_tool/soup.py
@@ -73,7 +73,8 @@ class Soup:
         # part 178 subpart 500 paragraph a subparagraph 1
         # sub-sub paragraph i sub-sub-sub paragraph A
         # i.e. 178.500 (a)(1)(i)(A)
-        letter_pattern = re.compile(r'\(([a-z])\)')
+
+        letter_pattern = re.compile(r'\((?=[a-z])([^i])\)') #all chars except i
         number_pattern = re.compile(r'\(([0-9]+)\)')
         numeral_pattern = re.compile(r'\(([ivx]+)\)') # this is horrible
         uppercase_letter_pattern = re.compile(r'\(([A-Z])\)')

--- a/cfr_tool/soup.py
+++ b/cfr_tool/soup.py
@@ -1,9 +1,12 @@
+from collections import defaultdict
 import logging
 import os
 
+import regex as re
 import requests
 import bs4
 import xml.etree.ElementTree as ET
+import networkx as nx
 
 class Soup:
     CACHE_DIRECTORY = "cfr_cache"
@@ -45,3 +48,49 @@ class Soup:
             'sectno', text="§ {}.{}".format(str(part), str(subpart)))
         return subpart_tag.parent
 
+    def get_subpart_paragraphs(self, part, subpart):
+        """
+        returns: a networkx graph object of the paragraphs of this subpart
+        """
+        subpart = self.get_subpart_text(part, subpart)
+        paragraphs = subpart.find_all("p")
+        indexed = list(self.gen_paragraph_tree(paragraphs))
+        ret_tree = nx.Graph()
+        for ix, paragraph in indexed:
+            canonical = ".".join(i for i in ix if i)
+            parent = ".".join(canonical.split(".")[:-1])
+            ret_tree.add_node(canonical, paragraph=paragraph)
+            if parent:
+                ret_tree.add_edge(parent, canonical)
+
+        return ret_tree 
+
+
+    @staticmethod
+    def gen_paragraph_tree(paragraphs):
+        # this reflects the nested paragraph structure
+        # e.g. you could look at
+        # part 178 subpart 500 paragraph a subparagraph 1
+        # sub-sub paragraph i sub-sub-sub paragraph A
+        # i.e. 178.500 (a)(1)(i)(A)
+        letter_pattern = re.compile(r'\(([a-z])\)')
+        number_pattern = re.compile(r'\(([0-9]+)\)')
+        numeral_pattern = re.compile(r'\(([ivx]+)\)') # this is horrible
+        uppercase_letter_pattern = re.compile(r'\(([A-Z])\)')
+
+        patterns = (letter_pattern, number_pattern, numeral_pattern, uppercase_letter_pattern)
+        # letter, number, numeral, uppercase
+        indices = [None, None, None, None]
+        def _reset_indices_after(ix):
+            for i in range(ix + 1, len(indices)):
+                indices[i] = None
+
+        for paragraph in paragraphs:
+            beginning = paragraph.text.strip()[:6]
+            for ix, pattern in enumerate(patterns):
+                match = pattern.findall(beginning)
+                if match:
+                    assert len(match) == 1
+                    indices[ix] = match[0]
+                    _reset_indices_after(ix)
+                    yield tuple(indices), paragraph

--- a/cfr_tool/soup.py
+++ b/cfr_tool/soup.py
@@ -1,16 +1,33 @@
+import os
+
 import requests
 import bs4
 import xml.etree.ElementTree as ET
 
 class Soup:
+    CACHE_DIRECTORY = "cfr_cache"
     def __init__(self, volume):
-    # govinfo xml url from which to parse the hazmat table
+        # govinfo xml url from which to parse the hazmat table
+        self.cfr = 
+        self.parsed_soup = bs4.BeautifulSoup(self.cfr, 'lxml')
+        self.volume = volume
+
+
+    def get_cfr_xml(self, volume):
         self.url = 'https://www.govinfo.gov/content/pkg/CFR-2019-title49-vol{}/xml/CFR-2019-title49-vol{}.xml'.format(
             str(volume), str(volume)
         )
-        self.cfr = requests.get(self.url)
-        self.parsed_soup = bs4.BeautifulSoup(self.cfr.text, 'lxml')
-        self.volume = volume
+       	self.cache_path = os.path.join(self.CACHE_DIRECTORY, self.url.split("/")[-1] )
+        if os.path.exists(self.cache_path):
+            with open(self.cache_path) as cache_xml:
+                xml = cache_xml.read()
+        else:
+            xml = requests.get(self.url).text
+            with open(self.cache_path, "w+") as cache_xml:
+                cache_xml.write(xml)
+ 
+        return xml
+            
     
     def find_table(self, table_title):
         tables = self.parsed_soup.find_all('gpotable')

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ Jinja2==2.11.2
 lxml==4.5.2
 MarkupSafe==1.1.1
 more-itertools==8.5.0
+networkx==2.5
 packaging==20.4
 parso==0.7.0
 pexpect==4.8.0


### PR DESCRIPTION
(Note: this branch is based on #7 )

@chankrista : this is my attempt to generalize how we're pulling these packaging codes out. At a high level, the idea is to specify the subpart where the definitions live (and the paragraph in the subpart that they are held in)... and then attempt to parse codes out of every sub-paragraph from there.

To that end, I wrote some code to more generally parse out the paragraphs of a subpart and put them into a nice tree structure using `networkx` (you'll need to install that to run this). Networkx is very slow but should be fine for our purposes here, we can refactor later if you think this is a good concept.


TODO: Update the load function to create a row for each code that comes out of get_categories. The load function should include reference to the part, subpart, paragraph, sub-paragraph (etc. up to the sub-sub-sub paragraph if it happens) where this definition came from.